### PR TITLE
Throw error in the default TileServer callback

### DIFF
--- a/lib/TileServer.js
+++ b/lib/TileServer.js
@@ -253,7 +253,7 @@ TileServer.prototype.getTile = function(layer, filename, x, y, z, callback) {
  * @return {void}
  */
 TileServer.prototype.listen = function(port, callback) {
-	callback = callback || function() {};
+	callback = callback || function(err) { if (err) throw err; };
 
 	var self = this;
 	var args = arguments;


### PR DESCRIPTION
When running a very simple project we don't have any callback, and so we don't see any errors, for example Mapnik raising an error when loading the XML.