### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ module.exports = function(options) {
 
 ### Multi-Function Plugins
 
-Sometimes a plugin must consist of multiple parts. For instance, a plugin tracking response times must register a request hook and response hook. To accomodate this, TileStrata supports arrays:
+Sometimes a plugin must consist of multiple parts. For instance, a plugin tracking response times must register a request hook and response hook. To accommodate this, TileStrata supports arrays:
 ```js
 module.exports = function() {
     return [


### PR DESCRIPTION
@naturalatlas, I've corrected a typographical error in the documentation of the [tilestrata](https://github.com/naturalatlas/tilestrata) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.