### PR TITLE
Don't send a Content-Length header for 204 (No Data) responses.

### DIFF
--- a/lib/TileServer.js
+++ b/lib/TileServer.js
@@ -230,7 +230,10 @@ TileServer.prototype.serve = function(req, http, callback) {
 		},
 		function finalizeResult(callback) {
 			if (!result.headers) result.headers = {};
-			result.headers['Content-Length'] = result.buffer && result.status !== 204 ? result.buffer.length : 0;
+
+			if (result.status !== 204) {
+				result.headers['Content-Length'] = result.buffer ? result.buffer.length : 0;
+			}
 
 			// head request support
 			if (req.method === 'HEAD') result.buffer = new Buffer([]);

--- a/lib/TileServer.js
+++ b/lib/TileServer.js
@@ -230,7 +230,7 @@ TileServer.prototype.serve = function(req, http, callback) {
 		},
 		function finalizeResult(callback) {
 			if (!result.headers) result.headers = {};
-			result.headers['Content-Length'] = result.buffer ? result.buffer.length : 0;
+			result.headers['Content-Length'] = result.buffer && result.status !== 204 ? result.buffer.length : 0;
 
 			// head request support
 			if (req.method === 'HEAD') result.buffer = new Buffer([]);


### PR DESCRIPTION
Some clients are quite picky about receiving 204 responses with a content-length header. This patch solves this by explicitly setting the Content-Length header to 0 for such responses (i.e. empty tiles).