### PR TITLE
/health should return a machine readable uptime

### DIFF
--- a/lib/routes/health.js
+++ b/lib/routes/health.js
@@ -11,7 +11,8 @@ module.exports = function(req, res, server) {
 			ok: true,
 			version: server.version,
 			host: host,
-			uptime: humanizeDuration(server.uptime().duration)
+			uptime: humanizeDuration(server.uptime().duration),
+			uptime_s: server.uptime().duration / 1000
 		}, result);
 
 		// show connection status w/upstream tilestrata balancer

--- a/test/TileServer.js
+++ b/test/TileServer.js
@@ -719,6 +719,7 @@ describe('TileServer', function() {
 							var parsedBody = JSON.parse(body);
 							assert.match(parsedBody.uptime, /^\d+(\.\d+)? seconds$/);
 							delete parsedBody.uptime;
+							delete parsedBody.uptime_s;
 							assert.deepEqual(parsedBody, expected);
 							assert.equal(res.headers['content-type'], 'application/json');
 							server.close(done);
@@ -740,6 +741,7 @@ describe('TileServer', function() {
 						res.on('end', function() {
 							var parsedBody = JSON.parse(body);
 							delete parsedBody.uptime;
+							delete parsedBody.uptime_s;
 							assert.equal(res.statusCode, 200);
 							assert.deepEqual(parsedBody, {
 								ok: true,
@@ -768,6 +770,7 @@ describe('TileServer', function() {
 						res.on('end', function() {
 							var parsedBody = JSON.parse(body);
 							delete parsedBody.uptime;
+							delete parsedBody.uptime_s;
 							assert.equal(res.statusCode, 500);
 							assert.deepEqual(parsedBody, {
 								ok: false,
@@ -793,6 +796,7 @@ describe('TileServer', function() {
 							var expected = {ok: true, version: pkg.version, host: '(hidden)'};
 							var parsedBody = JSON.parse(body);
 							delete parsedBody.uptime;
+							delete parsedBody.uptime_s;
 							assert.deepEqual(parsedBody, expected);
 							server.close(done);
 						});

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,7 @@ describe('require("tilestrata")', function() {
 			testMiddleware(middleware, '/tiles/health', false, {status: 200, headers: expected_headers, buffer: function(actual_buffer) {
 				var parsedBody = JSON.parse(actual_buffer);
 				delete parsedBody.uptime;
+				delete parsedBody.uptime_s;
 				assert.deepEqual(parsedBody, {ok: true, version: version, host: '(hidden)'});
 			}}, done);
 		});


### PR DESCRIPTION
Machines don't need human readable time strings... :)
