### PR TITLE
Option for omitting a filename 

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The version of TileStrata (useful to plugins, mainly).
 
 ##### layer.route(filename, [options])
 
-Registers a route. Returns a [TileRequestHandler](#tilerequesthandler) instance to be configured. The available options are:
+Registers a route. Returns a [TileRequestHandler](#tilerequesthandler) instance to be configured. Setting the filename to `*.{extension}` will omit the filename from the request and make the tiles available at `/{z}/{x}/{y}.{extension}` (see [#21](https://github.com/naturalatlas/tilestrata/pull/21)). The available options are:
 
   - **cacheFetchMode**: Defines how cache fetching happens when multiple caches are configured. The mode can be `"sequential"` or `"race"`. If set to `"race"`, TileStrata will fetch from all caches simultaneously and return the first that wins.
 

--- a/lib/TileRequest.js
+++ b/lib/TileRequest.js
@@ -15,7 +15,7 @@ function isInt(number) {
 	return !isNaN(number) && number === parseInt(number, 10);
 }
 
-TileRequest.parse = function(url, headers, method, noFilename) {
+TileRequest.parse = function(url, headers, method) {
 	if (!url) return;
 
 	// query string
@@ -32,13 +32,14 @@ TileRequest.parse = function(url, headers, method, noFilename) {
 	if (url.charAt(0) === '/') url = url.substring(1);
 
 	var parts = url.split('/');
-	if (noFilename && parts.length !== 4) return;
-	if (!noFilename && parts.length !== 5) return;
+	if (parts.length !== 4 && parts.length !== 5) return;
+
 	var layer = parts[0];
 	var z = Number(parts[1]);
 	var x = Number(parts[2]);
-	var y = (noFilename) ? Number(parts[3].split('.')[0]) : Number(parts[3]);
-	var filename = (noFilename) ? parts[3].split('.')[1] : parts[4];
+	var hasFilename = isNaN(Number(parts[3])) ? false : true
+	var y = hasFilename ? Number(parts[3]) :  Number(parts[3].split('.')[0]);
+	var filename = hasFilename ? parts[4] : '*.' + parts[3].split('.')[1];
 
 	if (!isInt(x)) return;
 	if (!isInt(y)) return;

--- a/lib/TileRequest.js
+++ b/lib/TileRequest.js
@@ -15,7 +15,7 @@ function isInt(number) {
 	return !isNaN(number) && number === parseInt(number, 10);
 }
 
-TileRequest.parse = function(url, headers, method) {
+TileRequest.parse = function(url, headers, method, noFilename) {
 	if (!url) return;
 
 	// query string
@@ -32,12 +32,13 @@ TileRequest.parse = function(url, headers, method) {
 	if (url.charAt(0) === '/') url = url.substring(1);
 
 	var parts = url.split('/');
-	if (parts.length !== 5) return;
+	if (noFilename && parts.length !== 4) return;
+	if (!noFilename && parts.length !== 5) return;
 	var layer = parts[0];
 	var z = Number(parts[1]);
 	var x = Number(parts[2]);
-	var y = Number(parts[3]);
-	var filename = parts[4];
+	var y = (noFilename) ? Number(parts[3].split('.')[0]) : Number(parts[3]);
+	var filename = (noFilename) ? parts[3].split('.')[1] : parts[4];
 
 	if (!isInt(x)) return;
 	if (!isInt(y)) return;

--- a/lib/TileServer.js
+++ b/lib/TileServer.js
@@ -133,7 +133,7 @@ TileServer.prototype._handleRequest = function(req, res, next) {
 		return route_robots(req, res, this);
 	}
 
-	var tilereq = TileRequest.parse(req.url, req.headers, req.method);
+	var tilereq = TileRequest.parse(req.url, req.headers, req.method, this.options.noFilename || false);
 	this.serve(tilereq, {req: req, res: res}, function(status, buffer, headers) {
 		if (next && status === 404) return next();
 		res.writeHead(status, headers);

--- a/lib/TileServer.js
+++ b/lib/TileServer.js
@@ -133,7 +133,7 @@ TileServer.prototype._handleRequest = function(req, res, next) {
 		return route_robots(req, res, this);
 	}
 
-	var tilereq = TileRequest.parse(req.url, req.headers, req.method, this.options.noFilename || false);
+	var tilereq = TileRequest.parse(req.url, req.headers, req.method);
 	this.serve(tilereq, {req: req, res: res}, function(status, buffer, headers) {
 		if (next && status === 404) return next();
 		res.writeHead(status, headers);

--- a/test/TileRequest.js
+++ b/test/TileRequest.js
@@ -42,6 +42,18 @@ describe('TileRequest', function() {
 			assert.equal(result.qs, 'query=1&test=2');
 			assert.deepEqual(result.headers, {});
 
+			// no filename
+			result = TileRequest.parse('lyr1/1/2/3.png', null, null, true);
+			assert.instanceOf(result, TileRequest);
+			assert.equal(result.layer, 'lyr1');
+			assert.equal(result.filename, 'png');
+			assert.equal(result.z, 1);
+			assert.equal(result.x, 2);
+			assert.equal(result.y, 3);
+			assert.equal(result.method, 'GET');
+			assert.equal(result.qs, undefined);
+			assert.deepEqual(result.headers, {});
+
 			// headers
 			result = TileRequest.parse('lyr1/1/2/3/tile@2x.png?query=1&test=2', {'x-tilestrata-skipcache': '1'});
 			assert.instanceOf(result, TileRequest);

--- a/test/TileRequest.js
+++ b/test/TileRequest.js
@@ -43,10 +43,10 @@ describe('TileRequest', function() {
 			assert.deepEqual(result.headers, {});
 
 			// no filename
-			result = TileRequest.parse('lyr1/1/2/3.png', null, null, true);
+			result = TileRequest.parse('lyr1/1/2/3.png', null, null);
 			assert.instanceOf(result, TileRequest);
 			assert.equal(result.layer, 'lyr1');
-			assert.equal(result.filename, 'png');
+			assert.equal(result.filename, '*.png');
 			assert.equal(result.z, 1);
 			assert.equal(result.x, 2);
 			assert.equal(result.y, 3);


### PR DESCRIPTION
Adds the option `noFilename` to the main tilestrata configuration parameters to allow for the `{z}/{x}/{y}.{extension}` request format.

While this is a global setting, I can also see arguments for having it be a route-specific parameter. 

To use it, simply pass `{noFilename: true}` when initializing the the tileserver, and pass the file extension in place of the filename (`.route('png')`) .

Let me know what you think!